### PR TITLE
Upgrade phase 0.0.27-1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  PHASE_VERSION: v0.0.27
+  PHASE_VERSION: v0.0.27-1
   PHASE_REPO: i3drobotics/phase
 
 jobs:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,7 +6,7 @@ on:
     types: [ opened, synchronize, reopened ]
 
 env:
-  PHASE_VERSION: v0.0.27
+  PHASE_VERSION: v0.0.27-1
   PHASE_REPO: i3drobotics/phase
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
           - prerelease
 
 env:
-  PHASE_VERSION: v0.0.27
+  PHASE_VERSION: v0.0.27-1
   PHASE_REPO: i3drobotics/phase
 
 jobs:

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,6 +1,6 @@
 FROM gitpod/workspace-full
 
-RUN curl --output phase.deb -L https://github.com/i3drobotics/phase/releases/download/v0.0.27/phase-v0.0.27-ubuntu-20.04-x86_64.deb && \
+RUN curl --output phase.deb -L https://github.com/i3drobotics/phase/releases/download/v0.0.27-1/phase-v0.0.27-1-ubuntu-20.04-x86_64.deb && \
     sudo apt update && \
     sudo apt install -y ./phase.deb && \
     sudo rm -rf ./phase.deb && \

--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ pip install ./phase-X.X.X-cpXXX-cpXXX-linux_x86_64.whl
 ## Dependencies
 Phase library is required to be installed for use in the build process.  
 ### Linux
-Download debian package from [v0.0.27 release](https://github.com/i3drobotics/phase/releases/tag/v0.0.27).  
+Download debian package from [v0.0.27-1 release](https://github.com/i3drobotics/phase/releases/tag/v0.0.27-1).  
 Install debian package using apt package manager:
 ```
 sudo apt install -f ./phase_vx.x.x-amd64.deb
 ```
 This should install to `/opt/i3dr/phase`
 ### Windows
-Download Windows installer from the [v0.0.27 release](https://github.com/i3drobotics/phase/releases/tag/v0.0.27).  
+Download Windows installer from the [v0.0.27-1 release](https://github.com/i3drobotics/phase/releases/tag/v0.0.27-1).  
 Install using the installer GUI, this should install to `C:\Program Files\i3DR\Phase`
 
 The following libraries are used to build pyPhase:

--- a/docs/README_developer.md
+++ b/docs/README_developer.md
@@ -7,14 +7,14 @@ Documenation for developers of pyPhase. pyPhase is a python wrapper over I3DR's 
 ## Install
 Phase library is required to be installed to use pyPhase.  
 >### Linux
->Download debian package from [v0.0.27 release](https://github.com/i3drobotics/phase/releases/tag/v0.0.27).  
+>Download debian package from [v0.0.27-1 release](https://github.com/i3drobotics/phase/releases/tag/v0.0.27-1).  
 >Install debian package using apt package manager:
 >```
 >sudo apt install -f ./phase_vx.x.x-amd64.deb
 >```
 >This should install to `/opt/i3dr/phase`
 >### Windows
->Download Windows installer from the [v0.0.27 release](https://github.com/i3drobotics/phase/releases/tag/v0.0.27).  
+>Download Windows installer from the [v0.0.27-1 release](https://github.com/i3drobotics/phase/releases/tag/v0.0.27-1).  
 >Install using the installer GUI, this should install to `C:\Program Files\i3DR\Phase`
 >
 
@@ -26,14 +26,14 @@ pip install phase
 ## Dependencies
 Phase library is required to be installed for use in the build process.  
 ### Linux
-Download debian package from [v0.0.27 release](https://github.com/i3drobotics/phase/releases/tag/v0.0.27).  
+Download debian package from [v0.0.27-1 release](https://github.com/i3drobotics/phase/releases/tag/v0.0.27-1).  
 Install debian package using apt package manager:
 ```
 sudo apt install -f ./phase_vx.x.x-amd64.deb
 ```
 This should install to `/opt/i3dr/phase`
 ### Windows
-Download Windows installer from the [v0.0.27 release](https://github.com/i3drobotics/phase/releases/tag/v0.0.27).  
+Download Windows installer from the [v0.0.27-1 release](https://github.com/i3drobotics/phase/releases/tag/v0.0.27-1).  
 Install using the installer GUI, this should install to `C:\Program Files\i3DR\Phase`
 
 The following libraries are used to build pyPhase:

--- a/src/package/phase/__init__.py
+++ b/src/package/phase/__init__.py
@@ -51,7 +51,7 @@ def check_phase_version(phase_version):
 
 
 # Define phase version
-phase_version = "0.0.27"
+phase_version = "0.0.27-1"
 
 # Check valid phase import
 import_phase()

--- a/src/package/phase/__init__.py
+++ b/src/package/phase/__init__.py
@@ -51,7 +51,7 @@ def check_phase_version(phase_version):
 
 
 # Define phase version
-phase_version = "0.0.27-1"
+phase_version = "0.0.27"
 
 # Check valid phase import
 import_phase()


### PR DESCRIPTION
Upgraded to Phase v0.0.27-1, this Phase release was to test some linker issues. Will use this test to inform the upgrade to v0.1.2-8.