### PR TITLE
add cmake template for pyphase version to add __version__ method to package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ test/.phase_test
 test/src/.phase_test
 deployment
 *.log
+src/bindings/pyphase_version_bindings.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,12 @@ project(pyphase LANGUAGES ${PROJECT_LANGS} VERSION ${VER})
 string(TOUPPER ${PROJECT_NAME} PROJECT_NAME_UPPER)
 string(TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWER)
 
+# create configure file (for version number as defines)
+configure_file(
+    src/bindings/cmake/pyphase_version_bindings.cpp.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/bindings/pyphase_version_bindings.cpp @ONLY
+)
+
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/src/bindings/cmake/pyphase_version_bindings.cpp.in
+++ b/src/bindings/cmake/pyphase_version_bindings.cpp.in
@@ -1,0 +1,18 @@
+/*!
+ * @authors Ben Knight (bknight@i3drobotics.com)
+ * @date 2021-05-26
+ * @copyright Copyright (c) I3D Robotics Ltd, 2021
+ * 
+ * @file pyphase_version_bindings.cpp
+ * @brief pyPhase version bindings
+ * @details Python bindings generated using pybind11
+ */
+
+#include "pybind11/pybind11.h"
+#include "ndarray_converter.h"
+
+namespace py = pybind11;
+
+void init_pyphase_version(py::module_ &m) {
+    m.attr("__version__") = @PROJECT_VERSION@;
+}

--- a/src/bindings/cmake/pyphase_version_bindings.cpp.in
+++ b/src/bindings/cmake/pyphase_version_bindings.cpp.in
@@ -14,5 +14,5 @@
 namespace py = pybind11;
 
 void init_pyphase_version(py::module_ &m) {
-    m.attr("__version__") = @PROJECT_VERSION@;
+    m.attr("__version__") = "@PROJECT_VERSION@";
 }

--- a/src/bindings/pyphase_bindings.cpp
+++ b/src/bindings/pyphase_bindings.cpp
@@ -16,6 +16,7 @@
 namespace py = pybind11;
 
 // pyphase
+void init_pyphase_version(py::module &);
 void init_version(py::module &);
 void init_utils(py::module &);
 
@@ -52,6 +53,7 @@ PYBIND11_MODULE(pyphase, m) {
     )";
     
     // pyphase
+    init_pyphase_version(m);
     init_version(m);
     init_utils(m);
 

--- a/src/bindings/version_bindings.cpp
+++ b/src/bindings/version_bindings.cpp
@@ -16,28 +16,28 @@
 namespace py = pybind11;
 
 void init_version(py::module_ &m) {
-    m.def("getPhaseVersionString", &I3DR::Phase::getVersionString, R"(
+    m.def("getAPIVersionString", &I3DR::Phase::getVersionString, R"(
         Get version of Phase
 
         Returns
         -------
         string : str
         )");
-    m.def("getPhaseVersionMajor", &I3DR::Phase::getVersionMajor, R"(
+    m.def("getAPIVersionMajor", &I3DR::Phase::getVersionMajor, R"(
         Get major of Phase
 
         Returns
         -------
         value : int
         )");
-    m.def("getPhaseVersionMinor", &I3DR::Phase::getVersionMinor, R"(
+    m.def("getAPIVersionMinor", &I3DR::Phase::getVersionMinor, R"(
         Get minor of Phase
 
         Returns
         -------
         value : int
         )");
-    m.def("getPhaseVersionPatch", &I3DR::Phase::getVersionPatch, R"(
+    m.def("getAPIVersionPatch", &I3DR::Phase::getVersionPatch, R"(
         Get version patch of Phase
 
         Returns

--- a/src/bindings/version_bindings.cpp
+++ b/src/bindings/version_bindings.cpp
@@ -3,8 +3,8 @@
  * @date 2021-05-26
  * @copyright Copyright (c) I3D Robotics Ltd, 2021
  * 
- * @file stereovision_bindings.cpp
- * @brief Phase class python bindings
+ * @file version_bindings.cpp
+ * @brief Phase version python bindings
  * @details Python bindings generated using pybind11
  */
 
@@ -16,28 +16,28 @@
 namespace py = pybind11;
 
 void init_version(py::module_ &m) {
-    m.def("getVersionString", &I3DR::Phase::getVersionString, R"(
+    m.def("getPhaseVersionString", &I3DR::Phase::getVersionString, R"(
         Get version of Phase
 
         Returns
         -------
         string : str
         )");
-    m.def("getVersionMajor", &I3DR::Phase::getVersionMajor, R"(
+    m.def("getPhaseVersionMajor", &I3DR::Phase::getVersionMajor, R"(
         Get major of Phase
 
         Returns
         -------
         value : int
         )");
-    m.def("getVersionMinor", &I3DR::Phase::getVersionMinor, R"(
+    m.def("getPhaseVersionMinor", &I3DR::Phase::getVersionMinor, R"(
         Get minor of Phase
 
         Returns
         -------
         value : int
         )");
-    m.def("getVersionPatch", &I3DR::Phase::getVersionPatch, R"(
+    m.def("getPhaseVersionPatch", &I3DR::Phase::getVersionPatch, R"(
         Get version patch of Phase
 
         Returns

--- a/src/package/phase/__init__.py
+++ b/src/package/phase/__init__.py
@@ -38,9 +38,9 @@ def import_phase():
 
 def check_phase_version(phase_version):
     # check Phase library included version matches expected version
-    from phase.pyphase import getVersionString
+    from phase.pyphase import getAPIVersionString
 
-    m_phase_version = getVersionString()
+    m_phase_version = getAPIVersionString()
     if m_phase_version != phase_version:
         error_msg = \
             "Phase library version mismatch. Expected v{} but got v{}.\n" \


### PR DESCRIPTION
pyPhase version and Phase API version should be seperated and pyPhase version should be presented using the standard __version__ method